### PR TITLE
Render in php

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ Performance is also important. The JS is lightweight and has no dependencies.
 
 The tabs block is made up of 2 blocks. A container tabs block, and a child tabs-item block. The tabs item block is simply a wrapper, allowing you to add any content you wish.
 
+## Saved markup.
+
+One of the aims of this block is to keep the markup very minimal. Something that will work even if this plugin is deactivated.
+
+All of the functionality and interactive elements are created on the fly either rendered server side or constructed in JS.
+
 ## Styling the tabs.
 
 The tabs are functional but unstyled.

--- a/blocks/src/tabs-item/block.json
+++ b/blocks/src/tabs-item/block.json
@@ -7,11 +7,15 @@
 		},
 		"title": {
 			"type": "string"
+		},
+		"parentId": {
+			"type": "string"
 		}
 	},
 	"description": "Preformatted block grouping for a single tabbed item.",
 	"editorScript": "file:./editor.js",
 	"name": "hm/tabs-item",
+	"render": "file:./render.php",
 	"parent": [ "hm/tabs" ],
 	"textdomain": "hm-tabs",
 	"title": "Tab Item",

--- a/blocks/src/tabs-item/render.php
+++ b/blocks/src/tabs-item/render.php
@@ -1,0 +1,16 @@
+<?php
+$p = new \WP_HTML_Tag_Processor( $content );
+
+if ( $p->next_tag( [ 'tag_name' => 'div', 'class_name' => 'hm-tabs-item' ] ) ) {
+	$p->set_attribute( 'role', 'tabpanel' );
+	$p->set_attribute( 'aria-labelledby', 'hm-tabs-nav-' . $attributes['id'] );
+	$p->set_attribute( 'tabindex', '0' );
+}
+
+if ( $p->next_tag( [ 'tag_name' => 'h2', 'class_name' => 'hm-tabs-item__title' ] ) ) {
+	$p->set_attribute( 'hidden', 'true' );
+	$p->set_attribute( 'style', 'display:none;' );
+}
+
+echo $p->get_updated_html(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+?>

--- a/blocks/src/tabs-item/save.js
+++ b/blocks/src/tabs-item/save.js
@@ -10,9 +10,6 @@ function Save( props ) {
 	const blockProps = useBlockProps.save( {
 		className: 'hm-tabs-item',
 		id: `hm-tabs-item-${ props.attributes.id }`,
-		role: 'tabpanel',
-		'aria-labelledby': `hm-tabs-nav-${ props.attributes.id }`,
-		tabindex: 0,
 	} );
 
 	const innerBlockProps = useInnerBlocksProps.save( {

--- a/blocks/src/tabs/block.json
+++ b/blocks/src/tabs/block.json
@@ -13,7 +13,7 @@
 	"icon": "block-default",
 	"keywords": [ "tabbed", "tabbed-content", "tabs" ],
 	"name": "hm/tabs",
-    "render": "file:./render.php",
+	"render": "file:./render.php",
 	"script": "file:./frontend.js",
 	"supports": {
 		"align": [ "full", "wide" ],

--- a/blocks/src/tabs/frontend.js
+++ b/blocks/src/tabs/frontend.js
@@ -147,6 +147,12 @@ function createTabs( blockElement ) {
  * @param {HTMLElement} blockElement Tab block.
  */
 function initTabBlock( blockElement ) {
+	// TODO: Re-use placeholder navigation elements instead of replacing.
+	const placeholderNav = blockElement.querySelector( '.hm-tabs__nav' );
+	if ( placeholderNav ) {
+		placeholderNav.parentNode.removeChild(  placeholderNav );
+	}
+
 	const tabsListElement = document.createElement( 'div' );
 	tabsListElement.classList.add( 'hm-tabs__nav' );
 	tabsListElement.setAttribute( 'role', 'tablist' );

--- a/blocks/src/tabs/render.php
+++ b/blocks/src/tabs/render.php
@@ -1,10 +1,42 @@
-<style>
-.hm-tabs-item__title {
-	display: none;
-}
-</style>
-
 <?php
-// Output saved block.
-echo $content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+
+// Load block content into dom document.
+$dom = new DOMDocument;
+libxml_use_internal_errors(true);
+$dom->loadHTML( $content );
+libxml_clear_errors();
+
+$xpath = new DOMXPath($dom);
+
+// Create tablist container div.
+$tablist_element = $dom->createElement('div');
+$tablist_element->setAttribute('class', 'hm-tabs__nav');
+$tablist_element->setAttribute('role', 'tablist');
+
+// Append a tab button for each tab item.
+$tab_title_elements = $xpath->query( '//h2[contains(@class, "hm-tabs-item__title")]' );
+foreach ( $tab_title_elements as $i => $tab_title_element ) {
+	$tab_id = $tab_title_element->parentNode->getAttribute( 'id' );
+	$button = $dom->createElement( 'button' );
+	$button->setAttribute( 'class', 'hm-tabs__nav-button' );
+	$button->setAttribute( 'role', 'tab' );
+	$button->setAttribute( 'tabindex', $i === 0 ? '0' : '-1' );
+	$button->setAttribute( 'aria-controls', $tab_id );
+	$button->setAttribute( 'id', str_replace( 'hm-tabs-item-', 'hm-tabs-button-', $tab_id ) );
+	$button->nodeValue = $tab_title_element->nodeValue;
+	$tablist_element->appendChild( $button );
+}
+
+// Prepend tab list to top of tab block.
+$tab_block_element = $xpath->query( '//div[contains(@class, "hm-tabs")][1]')->item(0);
+$tab_block_element->insertBefore( $tablist_element, $tab_block_element->firstChild );
+
+// Maybe add tablist container id data attribute.
+if ( ! empty( $attributes['tablistContainerId'] ) ) {
+	$tab_block_element->setAttribute( 'data-tablist-container-id', $attributes['tablistContainerId'] );
+}
+
+// Output modified HTML.
+echo $dom->saveHTML(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+
 ?>

--- a/blocks/src/tabs/save.js
+++ b/blocks/src/tabs/save.js
@@ -10,7 +10,6 @@ import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
 function Save( { attributes } ) {
 	const blockProps = useBlockProps.save( {
 		className: 'hm-tabs',
-		'data-tablist-container-id': attributes.tablistContainerId,
 	} );
 
 	const innerBlocksProps = useInnerBlocksProps.save( {


### PR DESCRIPTION
One of the aims I have with this is to keep the markup that is actually saved in the DB as clean and light as possible. This allows for the greatest flexibility and options to modify or customise in future. 

However I've run into a couple of problems here. 

1. Some of the required markup (e.g. `tabindex` attributes) is not allowed by kses and I'm reluctant to just add support for this as I have done in the past. In line with my goal stated above it's nice to avoid saving this in the content. Can add in PHP with `WP_HTML_Tag_Processor`.
2. Constructing the tab navigation in JS is causing some layout shift, but again, in-pursuit of the goal I had, I've been hoping to avoid saving the full markup as it makes it hard to change things in future. A nicer solution could be to construct the nav in PHP render which I've done here. Bit more involved than `WP_HTML_Tag_Processor` allows for unfortunately. 